### PR TITLE
chore(ci): add cache step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,13 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v4
 
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.deno
+            ~/.cache/deno
+          key: ${{ runner.os }}-deno-${{ hashFiles('**/deno.json') }}
+
       - name: Install Deno
         uses: denoland/setup-deno@v1
         with:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add caching for Deno dependencies in the deployment workflow to improve efficiency.