### PR TITLE
Add KWattByDayChart component for daily watt usage visualization

### DIFF
--- a/components/KWattByDayChart.tsx
+++ b/components/KWattByDayChart.tsx
@@ -1,50 +1,23 @@
 import { EChart } from "@/islands/EChart.tsx";
-import { type Temp } from "../libs/get_minipc_temp.ts";
 import type { ClickHouseResponse } from "@/libs/clickhouse.ts";
+import type { KWattByDay } from "@/libs/get_minipc_watt.ts";
 
-export function TempChart(
-  { temp, title }: { temp: ClickHouseResponse<Temp>; title: string },
+export function KWattByDayChart(
+  { wattByHour, title }: {
+    wattByHour: ClickHouseResponse<KWattByDay>;
+    title: string;
+  },
 ) {
-  const { data } = temp;
-  const labels = data.map((row) => row.created_at);
+  const { data } = wattByHour;
+  const labels = data.map((row) => row.day);
   const series = [
     {
-      name: "cpu_temp",
-      type: "line",
-      data: data.map((row) => Math.trunc(row.cpu_temp || 0)),
+      name: "Wh",
+      type: "bar",
+      data: data.map((row) => Math.trunc(row.total_wh || 0)),
       markPoint: {
         data: [
-          { type: "max", name: "max_cpu_temp" },
-        ],
-      },
-    },
-    {
-      name: "wifi_temp",
-      type: "line",
-      data: data.map((row) => Math.trunc(row.wifi_temp || 0)),
-      markPoint: {
-        data: [
-          { type: "max", name: "max_wifi_temp" },
-        ],
-      },
-    },
-    {
-      name: "ssd_temp",
-      type: "line",
-      data: data.map((row) => Math.trunc(row.ssd_temp || 0)),
-      markPoint: {
-        data: [
-          { type: "max", name: "max_ssd_temp" },
-        ],
-      },
-    },
-    {
-      name: "hdd_temp",
-      type: "line",
-      data: data.map((row) => Math.trunc(row.hdd_temp || 0)),
-      markPoint: {
-        data: [
-          { type: "max", name: "max_hdd_temp" },
+          { type: "max", name: "max_Wh" },
         ],
       },
     },
@@ -78,7 +51,7 @@ export function TempChart(
             scale: true,
             type: "value",
             axisLabel: {
-              formatter: "{value} °C",
+              formatter: "{value} kWh",
             },
           },
           series,

--- a/libs/get_minipc_temp.ts
+++ b/libs/get_minipc_temp.ts
@@ -1,15 +1,17 @@
 export interface Temp {
   created_at: string;
-  iwlwifi_temp?: number;
-  nvme_composite_temp?: number;
+  ssd_temp?: number;
+  hdd_temp?: number;
+  wifi_temp?: number;
   cpu_temp?: number;
 }
 
 export const query = `
   SELECT
       toStartOfHour(created_at) AS created_at,
-      avg(nvme_composite_temp) AS nvme_composite_temp,
-      avg(iwlwifi_temp) AS iwlwifi_temp,
+      avg(ssd_temp) AS ssd_temp,
+      avg(hdd_temp) AS hdd_temp,
+      avg(wifi_temp) AS wifi_temp,
       avg(cpu_temp) AS cpu_temp
   FROM duyet_analytics.homelab_ubuntu_sensors
   WHERE (toDateTime(created_at) >= toDateTime(now() - toIntervalDay(7))) AND (toDateTime(created_at) <= toDateTime(now()))

--- a/libs/get_minipc_temps_by_day.ts
+++ b/libs/get_minipc_temps_by_day.ts
@@ -4,7 +4,7 @@ export interface TempByDay {
   value: number;
 }
 
-export const query = `
+export const tempCPUByDayQuery = `
   SELECT
       toDate(created_at) AS day,
       toHour(created_at) AS hour,
@@ -17,3 +17,31 @@ export const query = `
     query_cache_nondeterministic_function_handling = 'save',
     query_cache_ttl = 3600
   `;
+
+export const tempSSDByDayQuery = `
+    SELECT
+        toDate(created_at) AS day,
+        toHour(created_at) AS hour,
+        avg(ssd_temp) AS value
+    FROM duyet_analytics.homelab_ubuntu_sensors
+    WHERE (toDateTime(created_at) >= toStartOfDay(now() - toIntervalDay(7)))
+    GROUP BY 1, 2
+    ORDER BY 1 DESC, 2 ASC WITH FILL
+    SETTINGS use_query_cache = 1,
+      query_cache_nondeterministic_function_handling = 'save',
+      query_cache_ttl = 3600
+    `;
+
+export const tempHDDByDayQuery = `
+    SELECT
+        toDate(created_at) AS day,
+        toHour(created_at) AS hour,
+        avg(hdd_temp) AS value
+    FROM duyet_analytics.homelab_ubuntu_sensors
+    WHERE (toDateTime(created_at) >= toStartOfDay(now() - toIntervalDay(7)))
+    GROUP BY 1, 2
+    ORDER BY 1 DESC, 2 ASC WITH FILL
+    SETTINGS use_query_cache = 1,
+      query_cache_nondeterministic_function_handling = 'save',
+      query_cache_ttl = 3600
+    `;

--- a/libs/get_minipc_watt.ts
+++ b/libs/get_minipc_watt.ts
@@ -1,4 +1,4 @@
-export interface WattByDay {
+export interface WattByDayHourMatrix {
   day: string;
   hour: string;
   value: number;
@@ -19,6 +19,45 @@ export const query = `
   FROM data
   GROUP BY 1, 2
   ORDER BY 1 DESC, 2 ASC
+  SETTINGS use_query_cache = 1,
+    query_cache_nondeterministic_function_handling = 'save',
+    query_cache_ttl = 3600
+  `;
+
+export interface KWattByDay {
+  day: string;
+  total_wh: number;
+  total_kwh: number;
+}
+
+export const queryKWattByDay = `
+WITH daily AS
+    (
+        SELECT
+            event_minute,
+            watts
+        FROM duyet_analytics.power_usage
+        WHERE host = hostName()
+          AND toDateTime(event_ts) >= toDateTime(now() - toIntervalDay(30))
+        ORDER BY event_minute ASC WITH FILL STEP toIntervalMinute(1)
+        INTERPOLATE ( watts AS watts )
+    )
+SELECT
+    toStartOfDay(event_minute) AS day,
+    count() AS measurements,
+    1440 AS expected_measurements,
+    -- Calculate daily Wh (watts * 1/60 hour/minute)
+    round(sum((watts) / 60), 3) AS total_wh,
+    -- Calculate daily kWh (watts * 0.001 kW/W * 1/60 hour/minute)
+    round(sum((watts * 0.001) / 60), 3) AS total_kwh,
+    round(avg(watts), 2) AS avg_watts,
+    min(watts) AS min_watts,
+    max(watts) AS max_watts,
+    round((count() / 1440) * 100, 2) AS coverage_percent,
+    multiIf(toStartOfDay(event_minute) = toDate(now()), 'Today', toStartOfDay(event_minute) = (toDate(now()) - 1), 'Yesterday', '') AS note
+FROM daily
+GROUP BY day
+ORDER BY day ASC
   SETTINGS use_query_cache = 1,
     query_cache_nondeterministic_function_handling = 'save',
     query_cache_ttl = 3600

--- a/routes/mini/index.tsx
+++ b/routes/mini/index.tsx
@@ -2,19 +2,30 @@ import { type RouteContext } from "$fresh/server.ts";
 
 import { query as tempQuery, type Temp } from "@/libs/get_minipc_temp.ts";
 import {
-  query as tempByDayQuery,
   type TempByDay,
+  tempCPUByDayQuery,
+  tempHDDByDayQuery,
+  tempSSDByDayQuery,
 } from "@/libs/get_minipc_temps_by_day.ts";
-import { query as wattQuery, type WattByDay } from "@/libs/get_minipc_watt.ts";
+import {
+  type KWattByDay,
+  query as wattQuery,
+  queryKWattByDay,
+  type WattByDayHourMatrix,
+} from "@/libs/get_minipc_watt.ts";
 import { TempChart } from "@/components/TempChart.tsx";
 import { TempHeatmapChart } from "@/components/TempHeatmapChart.tsx";
 import { WattHeatmapChart } from "@/components/WattHeatmapChart.tsx";
 import { clickhouseQuery } from "@/libs/clickhouse.ts";
+import { KWattByDayChart } from "@/components/KWattByDayChart.tsx";
 
 export default async function Page(_req: Request, _ctx: RouteContext) {
   const temp = await clickhouseQuery<Temp>(tempQuery);
-  const tempByDay = await clickhouseQuery<TempByDay>(tempByDayQuery);
-  const wattByDay = await clickhouseQuery<WattByDay>(wattQuery);
+  const tempCPUByDay = await clickhouseQuery<TempByDay>(tempCPUByDayQuery);
+  const tempSSDByDay = await clickhouseQuery<TempByDay>(tempSSDByDayQuery);
+  const tempHDDByDay = await clickhouseQuery<TempByDay>(tempHDDByDayQuery);
+  const wattByDay = await clickhouseQuery<WattByDayHourMatrix>(wattQuery);
+  const kWhByDay = await clickhouseQuery<KWattByDay>(queryKWattByDay);
 
   return (
     <div className="flex flex-col gap-8">
@@ -30,8 +41,8 @@ export default async function Page(_req: Request, _ctx: RouteContext) {
 
       <div>
         <TempHeatmapChart
-          temp={tempByDay}
-          title={"AMD Ryzen temperature (°C)"}
+          temp={tempCPUByDay}
+          title={"CPU AMD Ryzen temperature (°C)"}
         />
         <p className="mt-4">
           Data from k10temp sensor. Each row represents a day, and each square
@@ -40,9 +51,31 @@ export default async function Page(_req: Request, _ctx: RouteContext) {
       </div>
 
       <div>
+        <TempHeatmapChart
+          temp={tempSSDByDay}
+          title={"SSD temperature (°C)"}
+        />
+        <p className="mt-4">
+        </p>
+      </div>
+
+      <div>
+        <TempHeatmapChart
+          temp={tempHDDByDay}
+          title={"HDD temperature (°C)"}
+        />
+        <p className="mt-4">
+        </p>
+      </div>
+
+      <div>
         <WattHeatmapChart
           watts={wattByDay}
           title={"Power consumption (kWh)"}
+        />
+        <KWattByDayChart
+          wattByHour={kWhByDay}
+          title="Power consumption by day"
         />
         <p className="mt-4">
           Cron job that runs every minute using powerstat - a tool to measure


### PR DESCRIPTION
Introduce a new component to visualize daily watt usage and update related queries and data structures to support this feature. Adjust existing temperature data handling for consistency.

## Summary by Sourcery

Add a new `KWattByDayChart` component to visualize daily power usage. Update data queries to provide daily kWh data for the new chart and separate temperature data for CPU, SSD, and HDD. Display the separated temperature data in individual charts.

New Features:
- Introduce the `KWattByDayChart` component to visualize daily power consumption in kilowatt-hours (kWh).
- Separate temperature readings for CPU, SSD, and HDD, and visualize them in distinct charts.
- Add new queries and data handling to support daily kWh calculations and separate temperature readings by device