### PR TITLE
fix: show LiveUsersBadge on all pages even when no live users

### DIFF
--- a/islands/LiveUsersBadge.tsx
+++ b/islands/LiveUsersBadge.tsx
@@ -9,15 +9,6 @@ interface LiveUsersBadgeProps {
 export default function LiveUsersBadge({ initialStats }: LiveUsersBadgeProps) {
   const [stats, setStats] = useState<LiveStats>(initialStats);
 
-  if (stats.total === 0) {
-    return (
-      <LiveUpdates
-        initialStats={initialStats}
-        onUpdate={setStats}
-      />
-    );
-  }
-
   return (
     <>
       <LiveUpdates
@@ -29,7 +20,11 @@ export default function LiveUsersBadge({ initialStats }: LiveUsersBadgeProps) {
           href="/live"
           className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-full px-3 py-2 shadow-lg flex items-center gap-2 text-sm group hover:shadow-xl transition-all duration-200 hover:border-blue-300 dark:hover:border-blue-600 cursor-pointer"
         >
-          <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse">
+          <div
+            className={`w-2 h-2 rounded-full ${
+              stats.total > 0 ? "bg-green-500 animate-pulse" : "bg-gray-400"
+            }`}
+          >
           </div>
           <span className="font-medium text-gray-700 dark:text-gray-300 group-hover:text-blue-600 dark:group-hover:text-blue-400">
             {stats.total} live


### PR DESCRIPTION
## Summary
- Fix LiveUsersBadge disappearing when total users = 0
- Badge now always visible with proper visual indicators
- Green pulsing dot when users > 0, gray dot when 0 users
- Maintains clickable functionality and hover tooltip

## Problem
The badge was hidden completely when `stats.total === 0`, making it invisible on pages with no current live users.

## Solution
- Remove conditional rendering that hid the badge
- Add dynamic styling for the indicator dot based on user count
- Badge remains clickable and functional regardless of user count

## Changes
- `islands/LiveUsersBadge.tsx`: Remove conditional return, add dynamic dot styling

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Always render LiveUsersBadge with a dynamic dot indicator regardless of live user count

Bug Fixes:
- Display LiveUsersBadge even when there are zero live users

Enhancements:
- Show a gray static dot when live user count is zero and a green pulsing dot when users are present